### PR TITLE
Fix `configure()`

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -139,6 +139,6 @@ function wrapUiIfNeeded(innerElement: React.ReactNode, wrapperComponent?: React.
     : innerElement
 }
 
-export function configure(config: Partial<RenderConfiguration>): void {
-  Object.assign(config, config)
+export function configure(customConfig: Partial<RenderConfiguration>): void {
+  Object.assign(config, customConfig)
 }


### PR DESCRIPTION
`configure()` was assigning the custom config to itself instead of the shared `config`.

I'm also curious to know why it's under `/pure`. `configure` and `reactStrictMode` should be documented, no?