### PR TITLE
chore: rephrase the `act` comment in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ test('counter button increments the count', async () => {
 })
 ```
 
-> 💡 This library doesn't expose or use React's `act`. Instead, you should use Vitest's locators and `expect.element` API that have [retry-ability mechanism](https://vitest.dev/guide/browser/assertion-api) baked in.
+> 💡 This library doesn't expose React's `act` and uses it only for internal purposes. Instead, you should use Vitest's locators and `expect.element` API that have [retry-ability mechanism](https://vitest.dev/guide/browser/assertion-api) baked in.
 
 `vitest-browser-react` also automatically injects `render` method on the `page`. Example:
 


### PR DESCRIPTION
Update the readme to rephrase the comment that this library isn't using `act`.
`act` is currently used here: https://github.com/vitest-dev/vitest-browser-react/blob/main/src/pure.ts#L12