### PR TITLE
feat: add RenderOptions type for easier migration from RTL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { beforeEach } from 'vitest'
 import { cleanup, render } from './pure'
 
 export { render, renderHook, cleanup } from './pure'
-export type { ComponentRenderOptions, RenderHookOptions, RenderHookResult, RenderResult } from './pure'
+export type { ComponentRenderOptions, RenderHookOptions, RenderHookResult, RenderOptions, RenderResult } from './pure'
 
 page.extend({
   render,

--- a/src/pure.tsx
+++ b/src/pure.tsx
@@ -45,6 +45,8 @@ export interface ComponentRenderOptions {
   wrapper?: React.JSXElementConstructor<{ children: React.ReactNode }>
 }
 
+export interface RenderOptions extends ComponentRenderOptions {}
+
 // Ideally we'd just use a WeakMap where containers are keys and roots are values.
 // We use two variables so that we can bail out in constant time when we render with a new container (most common use case)
 const mountedContainers = new Set<Container>()


### PR DESCRIPTION
Closes #26

I kept `ComponentRenderOptions` for backwards compatibility and simply extended it just like `RenderHookOptions` implementation does.